### PR TITLE
Add trans snippet

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -54,5 +54,14 @@
             "{{ url('<front>') }}"
         ],
         "description": "Generate an absolute URL to the front page."
+    },
+    "Translation block helper": {
+        "prefix": "trans",
+        "body": [
+            "{% trans %}",
+            "\t${1:text}",
+            "{% endtrans %}"
+        ],
+        "description": "Allows translation for the content with the block"
     }
 }


### PR DESCRIPTION
This PR adds a `trans` snippet for facilitation Drupal 8 translations in twig.

https://www.drupal.org/docs/8/api/translation-api/overview#s-translation-in-twig-templates